### PR TITLE
A few ideas

### DIFF
--- a/misc/clock.ru
+++ b/misc/clock.ru
@@ -3,19 +3,29 @@
 require "rack"
 require 'agoo'
 
+$ticking = true
+# Note that the sender can become invalid at any time if the connection is
+# closed. It will raise an exception on send if that occurs.
+$publish_thread = Thread.new {
+  while $ticking do
+    now = Time.now
+    Agoo.publish channel: :time, message: ("%02d:%02d:%02d" % [now.hour, now.min, now.sec])
+    sleep(1)
+  end
+}
+
+
 class TickTock
   def initialize(env)
-    @ticking = true
-    # Note that the sender can become invalid at any time if the connection is
-    # closed. It will raise an exception on send if that occurs.
-    Thread.new {
-      while @ticking do
-	now = Time.now
-	@sender.write("%02d:%02d:%02d" % [now.hour, now.min, now.sec])
-      end
-    }
+    @env = env
   end
-  
+
+  def on_open(sender = nil)
+    # for iodine compatibility, as iodine doen't provide a sender object
+    @sender = sender ? sender : self
+    subscribe channel: :time
+  end
+
   def on_close
     # Shutdown the time publisher.
     @ticking = false
@@ -25,10 +35,14 @@ class TickTock
   # browser.
   def on_message(data)
     puts "received #{data}"
+    write("echo: #{data}")
   end
 
   # This is only needed for Iodine compatibility but can be used in any case.
   def write(data)
+    # iodine code
+    return super if defined?(super)
+    # Agoo code
     @sender.write(data)
   end
 
@@ -41,29 +55,20 @@ class FlyHandler
   # Normal HTTP request handler.
   def call(env)
     # This part is only needed for Iodine.
-    if env['HTTP_UPGRADE'.freeze] =~ /websocket/i
+    if env['upgrade.websocket?'.freeze]
       env['upgrade.websocket'.freeze] = TickTock.new(env)
       return [0, {}, []]
     end
     [ 200, { }, [ "flying fish clock" ] ]
   end
 
-  # This method is called when a WebSockets or SSE connection is
-  # established. The env argument is the same as what would be given to the
-  # call method except the env[`push.writer'] is set to a writer that can be
-  # used to push or publish data to the browser.
-  #
-  # Return a handler for on_message and on_close callbacks. This is
-  # optional. If nil is returned then broadcasts to the browsers are possible
-  # but not direct write from Ruby are. If the call raises an exception then
-  # the connection is closed.
-  def on_open(env)
-    TickTock.new(env)
-  end
-
 end
 
 run FlyHandler.new
+
+# close the publishing thread gracefully
+$ticking = false
+$publish_thread.join
 
 # A minimal startup of the Agoo rack handle using rackup and expecting a
 # WebSockets or SSE connection. Note this does not allow for loading any


### PR DESCRIPTION
1. I think it's possible to avoid a thread per connection and make this even more scalable using pub/sub and a single thread... what do you think?

2. I'm not super sold on the `@sender` idea, so I updated the example to support both approaches for now. When we look at any server side complexities I will rethink my approach.

3. I abstracted away the HTTP header details to use a boolean that should be set by the server (`env['upgrade.websocket?'`) this allows protocol changes and details to be hidden from the app (i.e., some servers might not support certain Websocket protocol versions). What do you think?