### PR TITLE
Additions and Rewrites

### DIFF
--- a/misc/SPEC
+++ b/misc/SPEC
@@ -128,7 +128,7 @@ Servers that choose to support WebSockets and SSE connections should follow thes
                       write(message)  # writes to the WebSocket or SSE connection
                       close()         # forces a close of the WebSocket or SSE connection
                       open?()         # returns true if the connection is open, false otherwise
-                      has_pending?()  # returns true if there's data that wasn't written to the socket's buffer and the server supports the if on_ready callback. otherwise returns false.
+                      pending?()      # returns true if there's data that wasn't written to the socket's buffer and the server supports the if on_ready callback. otherwise returns false.
                      This option should only be set it the environment options has a non-nil value for the <tt>rack.upgrade?</tt> option,
                      If the response status is 300 or higher, the server MUST ignore the <tt>rack.upgrade</tt> value (send the response without performing an upgrade).
 

--- a/misc/SPEC
+++ b/misc/SPEC
@@ -121,14 +121,14 @@ Servers that choose to support WebSockets and SSE connections should follow thes
                      The handler MAY implement any or all of the following callbacks:
                       on_open()                        # called when the connection is complete
                       on_message(message)              # called when a WebSocket message is received by server. <tt>message</tt> will be UTF-8 encoded for text messages and Binary encoded for binary messages.
-                      on_shutdown()                    # called before a connection is closed due to server shutdown (servers MAY implement this feature).
+                      on_shutdown()                    # may be called before a connection is closed due to server shutdown.
                       on_close()                       # called when the connection is closed
-                      on_ready()                       # called when the socket is ready to be written to (the socket's buffer has room to spare).
+                      on_ready()                       # may be called once for every time the socket's buffer changes from full to not-full.
                      The object will be extended by the server to include:
                       write(message)  # writes to the WebSocket or SSE connection
                       close()         # forces a close of the WebSocket or SSE connection
                       open?()         # returns true if the connection is open, false otherwise
-                      has_pending?()  # returns true if there's data that wasn't written to the socket's buffer.
+                      has_pending?()  # returns true if there's data that wasn't written to the socket's buffer and the server supports the if on_ready callback. otherwise returns false.
                      This option should only be set it the environment options has a non-nil value for the <tt>rack.upgrade?</tt> option,
                      If the response status is 300 or higher, the server MUST ignore the <tt>rack.upgrade</tt> value (send the response without performing an upgrade).
 

--- a/misc/SPEC
+++ b/misc/SPEC
@@ -114,20 +114,23 @@ be implemented by the server.
 <tt>rack.multipart.buffer_size</tt>:: An Integer hint to the multipart parser as to what chunk size to use for reads and writes.
 <tt>rack.multipart.tempfile_factory</tt>:: An object responding to #call with two arguments, the filename and content_type given for the multipart form field, and returning an IO-like object that responds to #<< and optionally #rewind. This factory will be used to instantiate the tempfile for each multipart form file upload field, rather than the default class of Tempfile.
 
-Optional environment specification are available on some server that support
-WebSockets and SSE.
-<tt>rack.upgrade?</tt>:: Is nil if no connection upgrade is possible,
+Servers that choose to support WebSockets and SSE connections should follow these additional environment specifications:
+<tt>rack.upgrade?</tt>:: Is nil or missing if no connection upgrade is possible,
                          :websocket for a WebSocket upgrade, or :sse for an SSE upgrade.
-<tt>rack.upgrade</tt>:: Is used to pass a handler back to the server for WebSocket and SSE connections.
-                     The handle may implement:
+<tt>rack.upgrade</tt>:: Is used to pass a handler instance or class back to the server for WebSocket and SSE connections.
+                     The handler MAY implement any or all of the following callbacks:
                       on_open()                        # called when the connection is complete
-                      on_message(message, subject=nil) # called when a WebSocket message is sent from the server
+                      on_message(message)              # called when a WebSocket message is received by server. <tt>message</tt> will be UTF-8 encoded for text messages and Binary encoded for binary messages.
+                      on_shutdown()                    # called before a connection is closed due to server shutdown (servers MAY implement this feature).
                       on_close()                       # called when the connection is closed
+                      on_ready()                       # called when the socket is ready to be written to (the socket's buffer has room to spare).
                      The object will be extended by the server to include:
                       write(message)  # writes to the WebSocket or SSE connection
                       close()         # forces a close of the WebSocket or SSE connection
+                      open?()         # returns true if the connection is open, false otherwise
+                      has_pending?()  # returns true if there's data that wasn't written to the socket's buffer.
                      This option should only be set it the environment options has a non-nil value for the <tt>rack.upgrade?</tt> option,
-                     The response should be 300 or greater to deny the upgrade or less than 300 to accept the connection upgrade.
+                     If the response status is 300 or higher, the server MUST ignore the <tt>rack.upgrade</tt> value (send the response without performing an upgrade).
 
 The server or the application can store their own data in the
 environment, too.  The keys must contain at least one dot,


### PR DESCRIPTION
A quick explanation of the changes:

* I added the `has_pending?` and `on_ready` that were requested as part of the previous attempt at a unified specification (or that's how I remember it).

* I added the `on_shutdown` callback. It's important for politely unwinding a process within a cluster, such as shutting down a Dyno in Heroku.

    I'm not sure servers should be forced to implement the feature, but it's nice to make it available for those that do - let me know what you think.

* I also changed the `on_message` signature. I didn't understand what purpose `subject` was serving, so I removed it.

* I allowed the `rack.upgrade?` to be missing as well as `nil` when the request isn't "upgradable".

* I also reworded some stuff for you to consider (just see if they feel clearer, English is not my native language so maybe my suggestions aren't all that great).

That's about it, I think... (to late, I might be forgetting what I did 5 minutes ago).
