### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/agoo.gemspec
+++ b/agoo.gemspec
@@ -27,8 +27,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.3.0'
   s.requirements << 'Linux or macOS'
 
-  s.rubyforge_project = 'agoo'
-
   s.add_development_dependency 'oj', '~> 3.7', '>= 3.7.1'
   
 end


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement.