### PR TITLE
Fix hijack test

### DIFF
--- a/test/hijack_test.rb
+++ b/test/hijack_test.rb
@@ -27,34 +27,33 @@ hello world|)
     end
   end
 
+  Minitest.after_run {
+    GC.start
+    Agoo::shutdown
+  }
+
   def test_hijack
-    begin
-      Agoo::Log.configure(dir: '',
-			  console: true,
-			  classic: true,
-			  colorize: true,
-			  states: {
-			    INFO: false,
-			    DEBUG: false,
-			    connect: false,
-			    request: false,
-			    response: false,
-			    eval: true,
-			  })
+    Agoo::Log.configure(dir: '',
+		  console: true,
+		  classic: true,
+		  colorize: true,
+		  states: {
+		    INFO: false,
+		    DEBUG: false,
+		    connect: false,
+		    request: false,
+		    response: false,
+		    eval: true,
+		  })
 
-      Agoo::Server.init(6471, 'root', thread_count: 1)
+    Agoo::Server.init(6471, 'root', thread_count: 1)
 
-      handler = HijackHandler.new
-      Agoo::Server.handle(:GET, "/hijack", handler)
+    handler = HijackHandler.new
+    Agoo::Server.handle(:GET, "/hijack", handler)
 
-      Agoo::Server.start()
+    Agoo::Server.start()
 
-      jack
-
-    ensure
-      GC.start
-      Agoo.shutdown
-    end
+    jack
   end
 
   def jack
@@ -72,5 +71,5 @@ hello world|)
 
     assert_equal('hello world', content, 'content mismatch')
   end
-  
+
 end

--- a/test/hijack_test.rb
+++ b/test/hijack_test.rb
@@ -14,7 +14,7 @@ require 'oj'
 
 require 'agoo'
 
-class RackHandlerTest < Minitest::Test
+class HijackHandlerTest < Minitest::Test
   class HijackHandler
     def call(env)
       io = env['rack.hijack'].call


### PR DESCRIPTION
Currently, `test/hijack_test.rb` does not show the test report. This is because `shutdown` calls `exit`. 
So I moved to `shutdown` to inside `Minitest.after_run` as well as other tests. 

Also, I fixed the test class name to matches to file name. Thanks.
