### PR TITLE
Remove duplicated `required_ruby_version`

### DIFF
--- a/agoo.gemspec
+++ b/agoo.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.summary = 'An HTTP server'
   s.description = 'A fast HTTP server supporting rack.'
   s.licenses = ['MIT']
-  s.required_ruby_version = '>= 2.0'
 
   s.files = Dir["{lib,ext,test}/**/*.{rb,h,c}"] + ['LICENSE', 'README.md', 'CHANGELOG.md']
   s.test_files = Dir["test/**/*.rb"]


### PR DESCRIPTION
It seems later specified is correct. So I removed the former.
https://github.com/ohler55/agoo/blob/fe16343679485009c7f1449046783110722d966a/agoo.gemspec#L27